### PR TITLE
Residual algorithm updates

### DIFF
--- a/antigen/config_files/schema/base_reduction_operations.yml
+++ b/antigen/config_files/schema/base_reduction_operations.yml
@@ -180,7 +180,7 @@ schema:
       needs: [ "trace_array", "good_fiber_mask", "master_arc_spec" ]
       provides: ["wavelength_solution", "fit_diagnostics", "fitted_arc_line_positions", "arc_pixel_locations"]
       algorithm:
-        function: "antigen.wavelength.get_wavelength"
+        function: "antigen.wavelength.get_wavelength_registration"
         args: ["master_arc_spec", "trace_array", "good_fiber_mask", "dispersion_reference_x", "arc_lines",
                "arc_flux_limit", "reference_fiber_index", "good_arc_residual_limit",
                "binned"]

--- a/antigen/config_files/schema/make_cubes_operations.yml
+++ b/antigen/config_files/schema/make_cubes_operations.yml
@@ -128,6 +128,10 @@ schema:
           type: ndarray
           required: true
           source: state
+        reduced_error:
+          type: ndarray
+          required: true
+          source: state
         fiber_x:
           type: ndarray
           required: true
@@ -169,11 +173,11 @@ schema:
           required: false
           default: "multiquadric"
           source: inputs.cli
-      needs: ["def_wave", "reduced_spectra", "fiber_x", "fiber_y", "modeling"]
-      provides: ["datacube", "x_grid", "y_grid"]
+      needs: ["def_wave", "reduced_spectra", "reduced_error", "fiber_x", "fiber_y", "modeling"]
+      provides: ["datacube", "errorcube", "x_grid", "y_grid"]
       algorithm:
         function: "antigen.cube.make_cube"
-        args: ["def_wave", "reduced_spectra", "fiber_x", "fiber_y", "fiber_radius", 
+        args: ["def_wave", "reduced_spectra", "reduced_error", "fiber_x", "fiber_y", "fiber_radius", 
                "modeling", "pixel_size", "interpolation_method", "rbf_function",
                "k_neighbors", "sigma_gdw"]
 
@@ -181,6 +185,10 @@ schema:
       description: "Save the datacube and coordinate grids to disk using write_cube function"
       params:
         datacube:
+          type: ndarray
+          required: true
+          source: state
+        errorcube:
           type: ndarray
           required: true
           source: state
@@ -216,10 +224,10 @@ schema:
           type: str
           required: true
           source: inputs.dataset
-      needs: ["datacube", "def_wave", "header", "x_grid", "y_grid"]
+      needs: ["datacube", "errorcube", "def_wave", "header", "x_grid", "y_grid"]
       provides: ["cube_filename"]
       algorithm:
         function: "antigen.io.write_cube"
         args: ["datacube", "def_wave", "header", "x_grid", "y_grid", "pixel_size",
-               "output_folder", "unit_instrument", "unit_id"]
+               "output_folder", "unit_instrument", "unit_id", "errorcube"]
 

--- a/antigen/cube.py
+++ b/antigen/cube.py
@@ -10,7 +10,7 @@ logger = logging.getLogger('antigen.cube')
 
 def fibers_to_image(fiber_x, fiber_y, fiber_flux, fiber_area, bounds=[-10., 10., -10., 10],
                     pixel_size=1.0, method="linear", rbf_func="multiquadric", k=5,
-                    sigma=1.0):
+                    sigma=1.0, fiber_error=None, return_error=False):
     """
     Create a synthetic image from non-uniform fiber locations and flux values.
 
@@ -34,10 +34,18 @@ def fibers_to_image(fiber_x, fiber_y, fiber_flux, fiber_area, bounds=[-10., 10.,
     Returns:
         img (ndarray): synthetic image on uniform grid
         X, Y (ndarray): meshgrid coordinates
+        (optionally) err_img (ndarray): synthetic error image if return_error=True
     """
     # Clean NaNs in flux and align x/y/flux
     finite_values = np.isfinite(fiber_flux)
     x, y, flux = (fiber_x[finite_values], fiber_y[finite_values], fiber_flux[finite_values])
+
+    # Prepare error values if requested
+    if return_error:
+        if fiber_error is None:
+            raise ValueError("return_error=True but fiber_error is None")
+        # Align error with finite flux mask and convert to variance for propagation
+        fiber_var = np.square(fiber_error)[finite_values]
 
     # Define grid
     grid_size_x = int((bounds[1] - bounds[0]) / pixel_size) + 1
@@ -47,27 +55,52 @@ def fibers_to_image(fiber_x, fiber_y, fiber_flux, fiber_area, bounds=[-10., 10.,
     yi = np.linspace(bounds[2], bounds[2] + (grid_size_y - 1) * pixel_size, grid_size_y)
     X, Y = np.meshgrid(xi, yi)
 
-    # If no valid input points, return zeros image
+    # If no valid input points, return zeros image (and error image)
     if x.size == 0:
         img = np.zeros_like(X, dtype=float)
+        err_img = np.zeros_like(X, dtype=float) if return_error else None
         # Correct for the area difference between the fiber size and the new pixel area
         flux_factor = pixel_size ** 2 / fiber_area
         img = img * flux_factor
+        if return_error:
+            err_img = err_img * flux_factor
+            return img, X, Y, err_img
         return img, X, Y
 
     flux_factor = pixel_size ** 2 / fiber_area
 
+    err_img = None
     if method in ["linear", "nearest", "cubic"]:
         # griddata can fail for too few points or outside convex hull; fall back to nearest
         try:
             img = griddata((x, y), flux, (X, Y), method=method)
         except Exception:
             img = griddata((x, y), flux, (X, Y), method="nearest")
+        if return_error:
+            if method == "nearest":
+                # Nearest-neighbor: propagate error directly
+                try:
+                    nearest_idx = griddata((x, y), np.arange(x.size), (X, Y), method="nearest").astype(int)
+                    var_img = fiber_var[nearest_idx]
+                except Exception:
+                    # Fallback: simple nearest on variance values
+                    var_img = griddata((x, y), fiber_var, (X, Y), method="nearest")
+            else:
+                # Approximate: interpolate variance field and take sqrt
+                try:
+                    var_img = griddata((x, y), fiber_var, (X, Y), method=method)
+                except Exception:
+                    var_img = griddata((x, y), fiber_var, (X, Y), method="nearest")
+            err_img = np.sqrt(np.clip(var_img, a_min=0.0, a_max=None))
 
     elif method == "rbf":
         # RBF interpolation
         rbf = Rbf(x, y, flux, function=rbf_func)
         img = rbf(X, Y)
+        if return_error:
+            rbf_var = Rbf(x, y, fiber_var, function=rbf_func)
+            var_img = rbf_var(X, Y)
+            err_img = np.sqrt(np.clip(var_img, a_min=0.0, a_max=None))
 
     elif method == "gdw":
         # Gaussian Distance Weighting (IDW-style)
@@ -75,6 +108,8 @@ def fibers_to_image(fiber_x, fiber_y, fiber_flux, fiber_area, bounds=[-10., 10.,
         k_eff = min(k, npts)
         if k_eff == 0:
             img = np.zeros_like(X, dtype=float)
+            if return_error:
+                err_img = np.zeros_like(X, dtype=float)
         else:
             tree = cKDTree(np.c_[x, y])
             dist, idx = tree.query(np.c_[X.ravel(), Y.ravel()], k=k_eff)
@@ -94,15 +129,22 @@ def fibers_to_image(fiber_x, fiber_y, fiber_flux, fiber_area, bounds=[-10., 10.,
 
             # Weighted sum of flux
             img = np.sum(weights * flux[idx], axis=1).reshape(X.shape)
+            if return_error:
+                # Variance propagation: sum(w^2 * var)
+                var_val = np.sum((weights ** 2) * fiber_var[idx], axis=1).reshape(X.shape)
+                err_img = np.sqrt(np.clip(var_val, a_min=0.0, a_max=None))
 
     else:
         raise ValueError(f"Unknown method {method}")
 
     # Correct for the area difference between the fiber size and the new pixel area
     img = img * flux_factor
+    if return_error:
+        err_img = err_img * flux_factor
+        return img, X, Y, err_img
     return img, X, Y
 
-def make_cube(wavelength, fiber_spectra, fiber_x, fiber_y, fiber_area,
+def make_cube(wavelength, fiber_spectra, fiber_error, fiber_x, fiber_y, fiber_area,
               modeling=None, pixel_size=1.0, method="linear",
               rbf_func="multiquadric", k=5, sigma=1.0):
     """Construct a 3D datacube from fiber spectra and positions.
@@ -133,6 +175,8 @@ def make_cube(wavelength, fiber_spectra, fiber_x, fiber_y, fiber_area,
         cube (ndarray):
             3D datacube with shape (N_lambda, Ny, Nx), where `Ny` and `Nx`
             are determined by the spatial extent of the fibers and `pixel_size`.
+        errorcube (ndarray):
+            3D error cube with propagated uncertainties matching cube shape.
         x_grid (ndarray): 2D array of x-locations.
         y_grid (ndarray): 2D array of y-locations.
     """
@@ -147,21 +191,28 @@ def make_cube(wavelength, fiber_spectra, fiber_x, fiber_y, fiber_area,
     # Determine spectral dimensions and guard against mismatches
     n_wave = int(len(wavelength))
     n_spec = int(fiber_spectra.shape[1])
-    n_lambda = min(n_wave, n_spec)
-    if n_wave != n_spec:
+    # error spectra expected to match fiber_spectra shape
+    if fiber_error is None:
+        raise ValueError("fiber_error must be provided to compute error cube")
+    if fiber_error.shape != fiber_spectra.shape:
+        logger.warning("fiber_error shape %s != fiber_spectra shape %s; proceeding with min common length along spectral axis", fiber_error.shape, fiber_spectra.shape)
+    n_spec_err = int(fiber_error.shape[1])
+    n_lambda = min(n_wave, n_spec, n_spec_err)
+    if not (n_wave == n_spec == n_spec_err):
         logger.warning(
-            "Wavelength grid length (%d) != spectra columns (%d). Proceeding with %d planes. "
-            "This often indicates an incorrect binning setting; check the --binned flag in antigen_make_cubes.py.",
-            n_wave, n_spec, n_lambda
+            "Wavelength grid length (%d) != spectra columns (%d) and/or error columns (%d). Proceeding with %d planes.",
+            n_wave, n_spec, n_spec_err, n_lambda
         )
 
-    # Allocate cube
+    # Allocate cubes
     cube = np.zeros((n_lambda, ny, nx), dtype=float)
+    errorcube = np.zeros((n_lambda, ny, nx), dtype=float)
     bounds = fiber.get_fiber_bounds(fiber_x, fiber_y)
 
     # Loop over wavelength bins
     for i, lam in enumerate(wavelength[:n_lambda]):
         flux = fiber_spectra[:, i]
+        ferr = fiber_error[:, i]
 
         if modeling is not None and 'dar_model' in modeling:
             # Apply DAR model directly to each fiber position at this wavelength
@@ -169,11 +220,14 @@ def make_cube(wavelength, fiber_spectra, fiber_x, fiber_y, fiber_area,
         else:
             x_shift, y_shift = fiber_x, fiber_y
 
-        image, x_grid, y_grid = fibers_to_image(
+        result = fibers_to_image(
             x_shift, y_shift, flux, fiber_area, bounds=bounds,
             pixel_size=pixel_size, method=method,
             rbf_func=rbf_func, k=k, sigma=sigma,
+            fiber_error=ferr, return_error=True,
         )
+        image, x_grid, y_grid, err_image = result
         cube[i] = image
+        errorcube[i] = err_image
 
-    return cube, x_grid, y_grid
+    return cube, errorcube, x_grid, y_grid

--- a/antigen/io.py
+++ b/antigen/io.py
@@ -523,7 +523,7 @@ def get_fits_files_in_path(input_path, pattern='*.fits'):
 
 
 def write_cube(cube, wavelength, header, x_grid, y_grid, pixel_size, 
-               output_folder=None, instrument=None, instrument_element=None, overwrite=True):
+               output_folder=None, instrument=None, instrument_element=None, errorcube=None, overwrite=True):
     """Write a spectral cube to a FITS file with relevant metadata.
 
     The function saves a datacube (lambda, y, x) to a FITS file, carrying
@@ -612,8 +612,25 @@ def write_cube(cube, wavelength, header, x_grid, y_grid, pixel_size,
     output_filename = os.path.abspath(os.path.join(output_folder, cube_name_stem + '.fits'))
 
     # Save FITS
-    hdu = fits.PrimaryHDU(data=cube.astype("float32"), header=hdr)
-    hdu.writeto(output_filename, overwrite=overwrite)
+    primary_hdu = fits.PrimaryHDU(data=cube.astype("float32"), header=hdr)
+    hdus = [primary_hdu]
+    if errorcube is not None:
+        err_hdu = fits.ImageHDU(data=errorcube.astype("float32"), name='ERROR')
+        # replicate minimal WCS meta for clarity on axes
+        err_hdu.header['CTYPE1'] = hdr.get('CTYPE1', 'X')
+        err_hdu.header['CTYPE2'] = hdr.get('CTYPE2', 'Y')
+        err_hdu.header['CTYPE3'] = hdr.get('CTYPE3', 'WAVE')
+        err_hdu.header['CDELT1'] = hdr.get('CDELT1', pixel_size)
+        err_hdu.header['CDELT2'] = hdr.get('CDELT2', pixel_size)
+        err_hdu.header['CDELT3'] = hdr.get('CDELT3', (wavelength[1]-wavelength[0]) if len(wavelength) > 1 else 1.0)
+        err_hdu.header['CRPIX1'] = hdr.get('CRPIX1', 1)
+        err_hdu.header['CRPIX2'] = hdr.get('CRPIX2', 1)
+        err_hdu.header['CRPIX3'] = hdr.get('CRPIX3', 1)
+        err_hdu.header['CRVAL1'] = hdr.get('CRVAL1', x_grid[0][0])
+        err_hdu.header['CRVAL2'] = hdr.get('CRVAL2', y_grid[0][0])
+        err_hdu.header['CRVAL3'] = hdr.get('CRVAL3', wavelength[0])
+        hdus.append(err_hdu)
+    fits.HDUList(hdus).writeto(output_filename, overwrite=overwrite)
     
     return output_filename
 

--- a/antigen/wavelength.py
+++ b/antigen/wavelength.py
@@ -5,11 +5,115 @@ from astropy.stats import mad_std
 from astropy.convolution import Gaussian1DKernel, convolve
 import numpy as np
 from scipy.signal import medfilt2d
+from skimage.registration import phase_cross_correlation
 
 from antigen.sky import identify_sky_pixels
 from antigen.trace import _get_peak_positions
 
 logger = logging.getLogger('antigen.wavelength')
+
+def get_wavelength_registration(spectra, trace_positions, valid_fibers, arc_pixel_guesses, arc_wavelengths,
+                   peak_threshold=5, reference_fiber_index=130,
+                   good_arc_residual_limit=0.2, binned=False):
+    """
+    Computes the wavelength solution for each fiber by identifying arc lamp emission line positions
+    in each fiber's spectrum, fits a smooth curve across the fiber direction, and derives a polynomial
+    mapping from pixel position to physical wavelength.
+
+    This 'new' version first performs an initial registration between the provided arc_pixel_guesses
+    and the reference fiber spectrum by cross-correlating a synthetic comb of Gaussian lines (at the
+    guessed positions) with the continuum-subtracted reference spectrum. The measured offset is applied
+    to the arc_pixel_guesses before proceeding with the rest of the wavelength solution.
+
+    Args:
+        spectra (ndarray): 2D array of flux values; each row is a fiber spectrum.
+        trace_positions (ndarray): 2D array with trace column positions for each fiber.
+        valid_fibers (ndarray): Boolean array indicating which fibers have valid data.
+        arc_pixel_guesses (ndarray): Initial pixel location guesses for each arc line.
+        arc_wavelengths (ndarray): Known wavelengths of arc lines.
+        peak_threshold (float, optional): Minimum peak height for a valid arc line (limit = peak_threshold * noise).
+        reference_fiber_index (int): Index of the fiber used as the starting point. Default is 130.
+        good_arc_residual_limit (float, optional): Maximum residual can be to be still called a good arc line to use
+        binned (bool, optional): Whether to bin the wavelength solution. Default is False.
+    Returns:
+        wavelength_solution (ndarray): Wavelength array for each fiber.
+        residuals (ndarray): Residuals from trace fitting per line.
+        fitted_trace_positions (ndarray): Smoothed trace-space positions of arc lines.
+        arc_pixel_locations (ndarray): Raw arc line pixel positions per fiber.
+    """
+    # Correct guesses for binning if requested
+    if binned:
+        arc_pixel_guesses = arc_pixel_guesses / 2.
+
+    logger.info("Starting wavelength solution (new) with initial registration for %d/%d fibers",
+                valid_fibers.sum(), spectra.shape[0])
+
+    # Step 1: Build a synthetic Gaussian comb at the arc_pixel_guesses and cross-correlate with
+    # the continuum-subtracted reference fiber to estimate a global pixel offset.
+    try:
+        n_pixels = spectra.shape[1]
+        # Guard against pathological inputs
+        if arc_pixel_guesses is None or len(arc_pixel_guesses) == 0:
+            logger.warning("No arc_pixel_guesses provided; skipping initial registration.")
+            initial_offset = 0.0
+        else:
+            # Continuum subtraction on the reference fiber
+            ref_flux = spectra[reference_fiber_index]
+            _, ref_cont = identify_sky_pixels(ref_flux, per=5)
+            ref_flux_corr = (ref_flux - ref_cont).astype(float)
+
+            # Do not apply additional normalization; only continuum subtraction as requested
+            # (retain original flux scaling for phase cross-correlation)
+
+            # Construct synthetic comb with unit Gaussians at guessed positions
+            x = np.arange(n_pixels, dtype=float)
+            synth = np.zeros(n_pixels, dtype=float)
+            # Reasonable sigma for unresolved arc lines in pixels
+            sigma = 1.5
+            valid_guesses = np.array(arc_pixel_guesses, dtype=float)
+            # Clip extreme guesses to safe margins to avoid underflow in exp
+            valid_guesses = valid_guesses[np.isfinite(valid_guesses)]
+            if valid_guesses.size == 0:
+                logger.warning("All arc_pixel_guesses are non-finite; skipping initial registration.")
+                initial_offset = 0.0
+            else:
+                for g in valid_guesses:
+                    # Skip wildly out-of-bounds guesses
+                    if g < -5 or g > n_pixels + 5:
+                        continue
+                    synth += np.exp(-0.5 * ((x - g) / sigma) ** 2)
+                # Use phase cross-correlation for subpixel registration (no normalization)
+                shift, error, diffphase = phase_cross_correlation(ref_flux_corr, synth, upsample_factor=10,
+                                                                  normalization=None)
+                # phase_cross_correlation returns the shift required to apply to 'synth' to align to 'ref_flux_corr'
+                # For 1D arrays, shift is a tuple with one element
+                initial_offset = float(shift[0])
+
+        if initial_offset != 0.0:
+            logger.info(f"Initial registration offset estimated: {initial_offset:+.3f} px")
+            # Apply offset to guesses and clip to detector bounds
+            arc_pixel_guesses = np.array(arc_pixel_guesses, dtype=float) + initial_offset
+            arc_pixel_guesses = np.clip(arc_pixel_guesses, 0, n_pixels - 1)
+    except Exception as e:
+        logger.exception("Initial registration step failed; proceeding without it: %s", e)
+
+    dispersion_axis = np.arange(trace_positions.shape[1])
+
+    # Proceed with the standard pipeline using the (possibly) adjusted guesses
+    arc_pixel_locations = _compute_arc_positions(spectra, valid_fibers, reference_fiber_index, arc_pixel_guesses,
+                                                 arc_wavelengths, peak_threshold)
+
+    fitted_arc_line_positions, residuals = _fit_arc_line_positions(arc_pixel_locations, trace_positions, valid_fibers)
+
+    wavelength_solution = _fit_wavelength_polynomials(fitted_arc_line_positions, arc_pixel_locations, arc_wavelengths,
+                                                      valid_fibers, dispersion_axis,
+                                                      good_arc_residual_limit=good_arc_residual_limit)
+
+    num_good_lines = np.sum(residuals < good_arc_residual_limit)
+    logger.info("Wavelength calibration (new) complete using %d out of %d arc lines",
+                num_good_lines, len(residuals))
+
+    return wavelength_solution, residuals, fitted_arc_line_positions, arc_pixel_locations
 
 def get_wavelength(spectra, trace_positions, valid_fibers, arc_pixel_guesses, arc_wavelengths,
                    peak_threshold=5, reference_fiber_index=130,

--- a/environment.yml
+++ b/environment.yml
@@ -13,6 +13,7 @@ dependencies:
   - psutil
   - scipy
   - scikit-learn
+  - scikit-image
   - seaborn
   - photutils
   - getcalspec


### PR DESCRIPTION
This PR introduces two major improvements to the reduction and cube-generation pipeline. First, the default wavelength calibration workflow now uses a new registration-based initialization step (get_wavelength_registration) that cross-correlates a synthetic arc-line comb with the continuum-subtracted reference fiber spectrum to estimate a global subpixel offset before fitting the wavelength solution. This is intended to improve robustness against detector shifts, imperfect arc guesses, and binning/configuration offsets while preserving the existing downstream fitting workflow. Second, the cube-generation pipeline now propagates uncertainties into a full 3D error cube. The changes add reduced_error as a required input, propagate variance through all supported interpolation methods, and write the resulting uncertainty information into an ERROR FITS extension alongside the science cube. The PR also adds scikit-image as a dependency to support the new phase cross-correlation registration step.